### PR TITLE
Add Claude Desktop Extension (.dxt) packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ config.yaml
 
 # uv
 uv.lock
+
+# DXT build artifacts (synced from src/ on each build)
+dxt/src/endnote_mcp/
+dxt/.venv/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,37 @@ Your references and PDF text are indexed into a local SQLite database with full-
 
 - **EndNote 20+** (any edition)
 - **Claude Desktop** app
-- **Python 3.10+**
-- **uv** (recommended) or pip
 
-## Quick Start
+The Desktop Extension installer below has no other prerequisites — Claude Desktop manages Python and dependencies. The CLI install path additionally needs Python 3.10+ and uv (or pip).
+
+## Install (Desktop Extension — Recommended)
+
+The fastest install for non-engineers. No Python or terminal required.
+
+1. **Export your library from EndNote.** File → Export → choose **XML** format → save somewhere like Desktop.
+2. **Download** `endnote-mcp.dxt` from the [latest release](https://github.com/gokmengokhan/endnote-mcp/releases).
+3. **Double-click the `.dxt` file** (or in Claude Desktop: Settings → Extensions → Install Extension…).
+4. In the install dialog, point Claude Desktop at:
+   - Your **EndNote XML** file (from step 1)
+   - Your **PDF Attachments Folder** — usually `<library>.Data/PDF/` next to your `.enl` file, or `PDF/` inside an `.enlp` package.
+5. Click Install. Claude Desktop will start indexing your library automatically — metadata is searchable within seconds, PDF text and semantic embeddings finish in the background.
+
+That's it. Try asking Claude *"Search my library for grounded theory"*.
+
+### Building the .dxt yourself
+
+Maintainers (or anyone working from source) can build the extension with:
+
+```bash
+bash scripts/build_dxt.sh
+# → dist/endnote-mcp.dxt
+```
+
+The build is a single cross-platform `.dxt` file (~36 KB). Dependencies resolve at install time via the `uv` runtime bundled with Claude Desktop.
+
+## Install (CLI / from PyPI)
+
+Prefer the terminal? This path gives you the `endnote-mcp` CLI for indexing and embedding.
 
 ### 1. Install
 
@@ -71,8 +98,6 @@ The wizard will:
 ### 4. Restart Claude Desktop
 
 Quit and reopen Claude Desktop. You'll see "EndNote Library" in your MCP connectors.
-
-That's it. Start asking Claude about your references.
 
 ## Semantic Search (Optional)
 

--- a/dxt/.mcpbignore
+++ b/dxt/.mcpbignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+*.egg-info/
+.DS_Store

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -1,0 +1,98 @@
+{
+  "manifest_version": "0.4",
+  "name": "endnote-mcp",
+  "display_name": "EndNote Library",
+  "version": "1.4.5",
+  "description": "Search, cite, and read PDFs from your EndNote library in Claude.",
+  "long_description": "Connect your EndNote reference library to Claude Desktop. Provides 12 tools for searching references by metadata, full-text search inside PDFs, semantic similarity search, generating citations in multiple styles (APA, Harvard, Vancouver, Chicago, IEEE), exporting BibTeX, and reading PDF pages directly. On first launch, indexes your library automatically — metadata is searchable in seconds; PDF text extraction and semantic embeddings continue in the background.",
+  "author": {
+    "name": "Gokhan Gokmen"
+  },
+  "homepage": "https://github.com/gokmengokhan/endnote-mcp",
+  "documentation": "https://github.com/gokmengokhan/endnote-mcp#readme",
+  "support": "https://github.com/gokmengokhan/endnote-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gokmengokhan/endnote-mcp"
+  },
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "endnote",
+    "references",
+    "citations",
+    "academic",
+    "research",
+    "literature",
+    "pdf",
+    "bibliography"
+  ],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": ["run", "--directory", "${__dirname}", "src/server.py"],
+      "env": {
+        "ENDNOTE_XML": "${user_config.endnote_xml}",
+        "ENDNOTE_PDF_DIR": "${user_config.pdf_dir}",
+        "ENDNOTE_MAX_PDF_PAGES": "${user_config.max_pdf_pages}",
+        "ENDNOTE_INDEX_PDFS_ON_FIRST_LAUNCH": "${user_config.extract_pdf_text}",
+        "ENDNOTE_GENERATE_EMBEDDINGS": "${user_config.semantic_search}"
+      }
+    }
+  },
+  "user_config": {
+    "endnote_xml": {
+      "type": "file",
+      "title": "EndNote XML Export",
+      "description": "Your EndNote XML file. Export from EndNote: File → Export → choose XML format.",
+      "required": true
+    },
+    "pdf_dir": {
+      "type": "directory",
+      "title": "PDF Attachments Folder",
+      "description": "The folder containing your PDF attachments — usually inside your library's .Data/PDF directory (or PDF/ inside an .enlp package).",
+      "required": true
+    },
+    "extract_pdf_text": {
+      "type": "boolean",
+      "title": "Enable full-text PDF search",
+      "description": "Extracts text from your PDFs so Claude can find quotes and passages inside papers. Adds about 1 minute per 100 PDFs on first launch (runs in the background — the server is usable immediately).",
+      "default": true
+    },
+    "semantic_search": {
+      "type": "boolean",
+      "title": "Enable semantic search",
+      "description": "Uses AI embeddings so Claude can find papers by meaning, not just keywords. Downloads a ~100 MB model on first use.",
+      "default": true
+    },
+    "max_pdf_pages": {
+      "type": "number",
+      "title": "Maximum pages per PDF read",
+      "description": "How many pages Claude can read from a single PDF in one tool call.",
+      "default": 30,
+      "min": 5,
+      "max": 200
+    }
+  },
+  "tools": [
+    {"name": "search_references", "description": "Search by title, author, keywords, or abstract."},
+    {"name": "search_fulltext", "description": "Search inside the PDF content of your references."},
+    {"name": "search_library", "description": "Combined metadata + PDF + semantic search."},
+    {"name": "search_semantic", "description": "Find papers by meaning using AI embeddings."},
+    {"name": "get_reference_details", "description": "Get full metadata for a reference."},
+    {"name": "get_citation", "description": "Format a single reference as a citation."},
+    {"name": "get_bibliography", "description": "Format multiple references as a bibliography."},
+    {"name": "get_bibtex", "description": "Export references as BibTeX entries."},
+    {"name": "read_pdf_section", "description": "Read pages from a reference's PDF."},
+    {"name": "list_references_by_topic", "description": "List references on a broad topic."},
+    {"name": "find_related", "description": "Find references related to a given reference."},
+    {"name": "rebuild_index", "description": "Re-index after adding new EndNote references."}
+  ],
+  "compatibility": {
+    "platforms": ["darwin", "linux", "win32"],
+    "runtimes": {
+      "python": ">=3.10"
+    }
+  }
+}

--- a/dxt/pyproject.toml
+++ b/dxt/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "endnote-mcp-dxt"
+version = "1.4.5"
+description = "Claude Desktop Extension wrapper for endnote-mcp"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.0.0",
+    "lxml>=5.0",
+    "PyMuPDF>=1.24",
+    "pyyaml>=6.0",
+    "click>=8.0",
+    "rich>=13.0",
+    "sentence-transformers>=2.2.0",
+    "sqlite-vec>=0.1.0",
+]

--- a/dxt/src/server.py
+++ b/dxt/src/server.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Claude Desktop Extension entry point for endnote-mcp.
+
+Translates user_config env vars (set by Claude Desktop) into a config.yaml,
+runs a fast synchronous metadata index so the MCP server is responsive within
+seconds, then kicks off PDF text extraction and semantic embeddings in a
+background thread before handing off to the MCP server's stdio loop.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+# Make the vendored endnote_mcp package importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import yaml  # noqa: E402
+
+from endnote_mcp.config import Config, get_config_dir, get_default_config_path  # noqa: E402
+
+
+def _log(msg: str) -> None:
+    """stderr is forwarded to Claude Desktop's MCP log viewer."""
+    print(f"[endnote-mcp] {msg}", file=sys.stderr, flush=True)
+
+
+def _truthy(value: str | None, default: bool) -> bool:
+    if value is None or value == "":
+        return default
+    return value.lower() not in ("false", "0", "no", "off")
+
+
+def _bootstrap_config() -> Path:
+    xml_env = os.environ.get("ENDNOTE_XML", "").strip()
+    pdf_env = os.environ.get("ENDNOTE_PDF_DIR", "").strip()
+
+    if not xml_env or not pdf_env:
+        _log("ERROR: extension is not configured.")
+        _log("Open Claude Desktop → Settings → Extensions → EndNote Library and set:")
+        _log("  • EndNote XML Export (file)")
+        _log("  • PDF Attachments Folder (directory)")
+        sys.exit(1)
+
+    xml_path = Path(xml_env).expanduser().resolve()
+    pdf_dir = Path(pdf_env).expanduser().resolve()
+
+    if not xml_path.exists():
+        _log(f"ERROR: EndNote XML file not found: {xml_path}")
+        sys.exit(1)
+    if not pdf_dir.exists():
+        _log(f"ERROR: PDF directory not found: {pdf_dir}")
+        sys.exit(1)
+
+    config_dir = get_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = get_default_config_path()
+
+    try:
+        max_pages = int(os.environ.get("ENDNOTE_MAX_PDF_PAGES") or 30)
+    except ValueError:
+        max_pages = 30
+
+    config = {
+        "endnote_xml": str(xml_path),
+        "pdf_dir": str(pdf_dir),
+        "db_path": str(config_dir / "library.db"),
+        "max_pdf_pages": max_pages,
+    }
+    with open(config_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+    _log(f"Config:  {config_path}")
+    _log(f"  XML:     {xml_path}")
+    _log(f"  PDFs:    {pdf_dir}")
+    _log(f"  DB:      {config['db_path']}")
+    return config_path
+
+
+def _xml_newer_than_db(cfg: Config) -> bool:
+    if not cfg.db_path.exists():
+        return True
+    try:
+        return cfg.endnote_xml.stat().st_mtime > cfg.db_path.stat().st_mtime
+    except OSError:
+        return True
+
+
+def _index_metadata_sync(cfg: Config) -> int:
+    """Parse XML and upsert reference rows. Fast — completes in seconds for thousands of refs."""
+    from endnote_mcp.db import connect, upsert_reference
+    from endnote_mcp.endnote_parser import parse_endnote_xml
+
+    conn = connect(cfg.db_path)
+    ref_count = 0
+    pdf_count = 0
+    for ref in parse_endnote_xml(cfg.endnote_xml):
+        upsert_reference(conn, ref)
+        ref_count += 1
+        if ref.get("pdf_path"):
+            pdf_count += 1
+        if ref_count % 1000 == 0:
+            conn.commit()
+    conn.commit()
+    conn.close()
+    _log(f"Indexed {ref_count} references ({pdf_count} have PDFs).")
+    return ref_count
+
+
+def _background_index(cfg: Config, *, do_pdfs: bool, do_embeddings: bool) -> None:
+    """PDF text extraction + semantic embeddings. Runs in a background thread."""
+    try:
+        if do_pdfs:
+            _extract_pending_pdfs(cfg)
+        if do_embeddings:
+            _embed_pending_references(cfg)
+        _log("Background indexing complete.")
+    except Exception as e:
+        _log(f"Background indexing error: {e}")
+
+
+def _extract_pending_pdfs(cfg: Config) -> None:
+    from endnote_mcp.db import connect, insert_pdf_page
+    from endnote_mcp.pdf_indexer import extract_pages, find_pdf
+
+    conn = connect(cfg.db_path)
+    rows = conn.execute(
+        """
+        SELECT r.rec_number, r.pdf_path
+        FROM references_ r
+        WHERE r.pdf_path IS NOT NULL AND r.pdf_path != ''
+          AND r.rec_number NOT IN (SELECT rec_number FROM pdf_pages)
+        """
+    ).fetchall()
+
+    if not rows:
+        conn.close()
+        return
+
+    _log(f"Background: extracting text from {len(rows)} PDFs (this can take a while)...")
+
+    max_size = 200 * 1024 * 1024
+    ok = fail = skipped = total_pages = 0
+
+    for i, row in enumerate(rows, 1):
+        rec_number = row["rec_number"]
+        pdf_path = find_pdf(cfg.pdf_dir, row["pdf_path"])
+        if pdf_path is None:
+            fail += 1
+            continue
+        try:
+            size = pdf_path.stat().st_size
+        except OSError:
+            fail += 1
+            continue
+        if size > max_size:
+            skipped += 1
+            continue
+
+        timeout = 120 if size > 50 * 1024 * 1024 else 30
+        try:
+            pages = 0
+            for page_num, text in extract_pages(pdf_path, timeout=timeout):
+                insert_pdf_page(conn, rec_number, page_num, text)
+                pages += 1
+            total_pages += pages
+            ok += 1
+        except Exception:
+            fail += 1
+
+        if i % 25 == 0:
+            conn.commit()
+            _log(f"  PDFs: {ok} ok / {fail} failed / {skipped} skipped (of {i}/{len(rows)})")
+
+    conn.commit()
+    conn.close()
+    _log(f"PDFs: {ok} extracted ({total_pages} pages), {fail} failed, {skipped} skipped (>200 MB).")
+
+
+def _embed_pending_references(cfg: Config) -> None:
+    try:
+        from endnote_mcp import embeddings
+    except Exception as e:
+        _log(f"Semantic search unavailable ({e}); skipping embeddings.")
+        return
+
+    if not embeddings.is_available():
+        _log("Semantic search dependencies not installed; skipping embeddings.")
+        return
+
+    from endnote_mcp.db import connect, upsert_embedding
+
+    conn = connect(cfg.db_path)
+    rows = conn.execute(
+        """
+        SELECT r.rec_number, r.title, r.abstract, r.keywords
+        FROM references_ r
+        WHERE r.rec_number NOT IN (SELECT rec_number FROM reference_embeddings)
+        """
+    ).fetchall()
+
+    if not rows:
+        conn.close()
+        return
+
+    _log(f"Background: generating semantic embeddings for {len(rows)} references...")
+    _log(f"Loading embedding model {embeddings.MODEL_NAME} (downloads ~100 MB on first use)...")
+    model = embeddings.load_model()
+
+    batch_size = 64
+    embedded = 0
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i:i + batch_size]
+        texts: list[str] = []
+        rec_numbers: list[int] = []
+        for row in batch:
+            text = embeddings.build_search_text({
+                "title": row["title"],
+                "abstract": row["abstract"],
+                "keywords": row["keywords"],
+            })
+            if text.strip():
+                texts.append(text)
+                rec_numbers.append(row["rec_number"])
+        if texts:
+            blobs = embeddings.encode_batch(model, texts)
+            for rn, blob in zip(rec_numbers, blobs):
+                upsert_embedding(conn, rn, blob, embeddings.MODEL_NAME)
+            embedded += len(blobs)
+
+        if (i // batch_size) % 4 == 0:
+            conn.commit()
+            _log(f"  Embeddings: {embedded}/{len(rows)}")
+
+    conn.commit()
+    conn.close()
+    _log(f"Embeddings: {embedded} generated.")
+
+
+def main() -> None:
+    config_path = _bootstrap_config()
+    cfg = Config.load(config_path)
+
+    do_pdfs = _truthy(os.environ.get("ENDNOTE_INDEX_PDFS_ON_FIRST_LAUNCH"), True)
+    do_embeddings = _truthy(os.environ.get("ENDNOTE_GENERATE_EMBEDDINGS"), True)
+
+    if _xml_newer_than_db(cfg):
+        _log("Indexing reference metadata...")
+        _index_metadata_sync(cfg)
+    else:
+        _log("Metadata index up to date.")
+
+    if do_pdfs or do_embeddings:
+        threading.Thread(
+            target=_background_index,
+            args=(cfg,),
+            kwargs={"do_pdfs": do_pdfs, "do_embeddings": do_embeddings},
+            daemon=True,
+            name="endnote-mcp-bg-index",
+        ).start()
+
+    _log("Starting MCP server.")
+    from endnote_mcp.server import mcp
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_dxt.sh
+++ b/scripts/build_dxt.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the endnote-mcp Claude Desktop Extension (.dxt).
+#
+# This produces a single cross-platform .dxt file that Claude Desktop can
+# install. Dependencies are resolved at install time by uv (bundled with
+# Claude Desktop), so no per-platform builds are needed.
+#
+# Output:  dist/endnote-mcp.dxt
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DXT_DIR="dxt"
+DIST_DIR="dist"
+OUTPUT="$DIST_DIR/endnote-mcp.dxt"
+
+if [ ! -f "$DXT_DIR/manifest.json" ]; then
+  echo "error: $DXT_DIR/manifest.json missing — run from repo root" >&2
+  exit 1
+fi
+
+# Sync the package source from src/endnote_mcp/ into dxt/src/endnote_mcp/.
+# We re-copy on every build so the DXT always reflects the latest source.
+echo "Syncing endnote_mcp package source..."
+rm -rf "$DXT_DIR/src/endnote_mcp"
+mkdir -p "$DXT_DIR/src"
+cp -R "src/endnote_mcp" "$DXT_DIR/src/endnote_mcp"
+
+# Strip caches from the synced copy.
+find "$DXT_DIR/src/endnote_mcp" -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null || true
+find "$DXT_DIR/src/endnote_mcp" -name "*.pyc" -delete 2>/dev/null || true
+
+# Pack into a .dxt zip.
+mkdir -p "$DIST_DIR"
+rm -f "$OUTPUT"
+
+(
+  cd "$DXT_DIR"
+  zip -rq "../$OUTPUT" . \
+    -x "*.pyc" \
+    -x "**/__pycache__/*" \
+    -x ".venv/*" \
+    -x "*.egg-info/*" \
+    -x ".DS_Store"
+)
+
+SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo
+echo "Built $OUTPUT ($SIZE)"
+echo
+echo "Install instructions:"
+echo "  Double-click the .dxt file, or"
+echo "  Claude Desktop → Settings → Extensions → Install Extension..."


### PR DESCRIPTION
Bundles endnote-mcp as a single cross-platform .dxt installable by double-click in Claude Desktop. Uses manifest_version 0.4 with server.type "uv", so dependencies (including semantic search) are resolved at install time and no Python install is required from the end user.

The bootstrap entry point reads user_config env vars set by Claude Desktop, writes config.yaml, runs a fast synchronous metadata index, then continues PDF text extraction and embedding generation in a background thread before handing off to the MCP stdio loop.